### PR TITLE
Increasing the load from 0.005

### DIFF
--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -17,7 +17,7 @@
 journeys {
   disclosure-company = {
     description = "Submit a new disclosure (company)"
-    load = 0.005
+    load = 0.05
     parts = [
       auth-login,
       using-this-service,


### PR DESCRIPTION
Increase the load to test if a higher load would affect the service.

The 0.005 figure comes from the number of disclosures we expect to get a year, but this means that we are only running 3 journeys over the 8 minutes which isn't much of a stress test. We're increasing the load by a factor of 10 so it should run 30 journeys.